### PR TITLE
Check ES version before getting metadata index

### DIFF
--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -50,27 +50,58 @@ export default function metadataHandler(request, response) {
    * @type {ElastalertServer}
    */
   var client = getClient();
+  var index;
 
-  client.search({
-    index: config.get('writeback_index'),
-    type: request.params.type,
-    body: {
-      from : request.query.from || 0, 
-      size : request.query.size || 100,
-      query: {
-        query_string: {
-          query: getQueryString(request)
-        }
-      },
-      sort: [{ '@timestamp': { order: 'desc' } }]
-    }
-  }).then(function(resp) {
-    resp.hits.hits = resp.hits.hits.map(h => h._source);
-    response.send(resp.hits);
+  client.info().then(function(resp) {
+    return parseInt(resp.version.number.split(".")[0], 10);
   }, function(err) {
     response.send({
       error: err
     });
+  }).then(function(es_version) {
+    if (es_version > 5) {
+      switch(request.params.type) {
+        case 'elastalert':
+          index = config.get('writeback_index')
+          break;
+        case 'elastalert_status':
+          index = config.get('writeback_index') + '_status'
+          break;
+        case 'silence':
+          index = config.get('writeback_index') + '_silence'
+          break;
+        case 'elastalert_error':
+          index = config.get('writeback_index') + '_error'
+          break;
+        case 'past_elastalert':
+          index = config.get('writeback_index') + '_past'
+          break;
+        default:
+          // code block
+      }
+    } else {
+      index = config.get('writeback_index')
+    }
+    client.search({
+      index: index,
+      type: request.params.type,
+      body: {
+        from: request.query.from || 0,
+        size: request.query.size || 100,
+        query: {
+          query_string: {
+            query: getQueryString(request)
+          }
+        },
+        sort: [{ '@timestamp': { order: 'desc' } }]
+      }
+    }).then(function(resp) {
+      resp.hits.hits = resp.hits.hits.map(h => h._source);
+      response.send(resp.hits);
+    }, function(err) {
+      response.send({
+        error: err
+      });
+    });
   });
-
 }


### PR DESCRIPTION
This close ServerCentral/praeco#100.

Before getting data from writeback indexes, it calls es api to get version.
Then it construct index name, because name is different between es5 and es6.