### PR TITLE
Enable usage of ssl certificates for ElasticSearch connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ You can use the following config options:
   },
   "es_host": "localhost", // For getting metadata and field mappings, connect to this ES server
   "es_port": 9200, // Port for above
+  "es_ssl": true, // Enable/Disable SSL
+  "es_ca_certs": "/etc/ssl/elasticsearch/ca", // Path to ca for ElasticSearch (SSL must be enabled)
+  "es_client_cert": "/etc/ssl/elasticsearch/cert", // Path to cert for ElasticSearch (SSL must be enabled)
+  "es_client_key": "/etc/ssl/elasticsearch/key", // Path to key for ElasticSearch (SSL must be enabled)
   "writeback_index": "elastalert_status" // Writeback index to examine for /metadata endpoint
 }
 ```

--- a/src/common/elasticsearch_client.js
+++ b/src/common/elasticsearch_client.js
@@ -76,9 +76,21 @@ export function clientSearch(index, type, qs, request, response) {
 
 export function getClient() {
   let scheme = 'http';
+  let ssl_body = {};
 
   if (config.get('es_ssl')) {
     scheme = 'https';
+    ssl_body.rejectUnauthorized = true;
+
+    if (config.get('es_ca_certs')) {
+      ssl_body.ca = fs.readFileSync(config.get('es_ca_certs'));
+    }
+    if (config.get('es_client_cert')) {
+      ssl_body.cert = fs.readFileSync(config.get('es_client_cert'));
+    }
+    if (config.get('es_client_key')) {
+      ssl_body.key = fs.readFileSync(config.get('es_client_key'));
+    }
   }
 
   let auth = '';
@@ -86,9 +98,10 @@ export function getClient() {
   if (config.get('es_username') && config.get('es_password')) {
     auth = `${config.get('es_username')}:${config.get('es_password')}@`;
   }
-  
+
   var client = new elasticsearch.Client({
-    hosts: [ `${scheme}://${auth}${config.get('es_host')}:${config.get('es_port')}`]
+    hosts: [ `${scheme}://${auth}${config.get('es_host')}:${config.get('es_port')}`],
+    ssl: ssl_body
   });
 
   return client;


### PR DESCRIPTION
I am using ElastalertServer in an OpenShift environment and therefore I had to do the following modification in order to get ElastalertServer connected with ElasticSearch.