### PR TITLE
Remove mapping type from search fields.

### DIFF
--- a/src/handlers/metadata/get.js
+++ b/src/handlers/metadata/get.js
@@ -92,7 +92,6 @@ export function metadataElastalertHandler(request, response) {
 
   client.search({
     index,
-    type: 'elastalert',
     body: {
       from: request.query.from || 0,
       size: request.query.size || 100,


### PR DESCRIPTION
Removes mapping type as a search parameter when querying alert logs.

Mapping types were removed in ElasticSearch 7.x, and attempting to search by mapping type will prevent results from being returned.